### PR TITLE
アイコン表示の ; を : に変更

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -204,7 +204,7 @@ function actualDateOfSchedule({ startDate }: BlogRelayInfo, schedule: Schedule):
 
 function scheduleToStringInCalendar(schedule: Schedule): string {
     const writerIcons = Array.from(schedule.writer.matchAll(WRITER_REGEXP))
-        .map((match) => ":" + match[0] + ":")
+        .map((match) => `:${match[0]}:`)
         .join("")
     return writerIcons
 }

--- a/main.ts
+++ b/main.ts
@@ -204,9 +204,9 @@ function actualDateOfSchedule({ startDate }: BlogRelayInfo, schedule: Schedule):
 
 function scheduleToStringInCalendar(schedule: Schedule): string {
     const writerIcons = Array.from(schedule.writer.matchAll(WRITER_REGEXP))
-        .map((match) => match[0])
-        .join("::")
-    return ":" + writerIcons + ":"
+        .map((match) => ":" + match[0] + ":")
+        .join("")
+    return writerIcons
 }
 
 function schedulesToCalendar(blogRelayInfo: BlogRelayInfo, schedules: Schedule[]): string {

--- a/main.ts
+++ b/main.ts
@@ -203,7 +203,10 @@ function actualDateOfSchedule({ startDate }: BlogRelayInfo, schedule: Schedule):
 }
 
 function scheduleToStringInCalendar(schedule: Schedule): string {
-    return schedule.writer.replace(/;/g, ":")
+    const writerIcons = Array.from(schedule.writer.matchAll(WRITER_REGEXP))
+        .map((match) => match[0])
+        .join("::")
+    return ":" + writerIcons + ":"
 }
 
 function schedulesToCalendar(blogRelayInfo: BlogRelayInfo, schedules: Schedule[]): string {

--- a/main.ts
+++ b/main.ts
@@ -203,7 +203,7 @@ function actualDateOfSchedule({ startDate }: BlogRelayInfo, schedule: Schedule):
 }
 
 function scheduleToStringInCalendar(schedule: Schedule): string {
-    return schedule.writer
+    return schedule.writer.replace(/;/g, ":")
 }
 
 function schedulesToCalendar(blogRelayInfo: BlogRelayInfo, schedules: Schedule[]): string {


### PR DESCRIPTION
Wikiから担当者のアイコンを持ってくるだけだとブログ担当者のカレンダー表記がおかしくなるのでその修正
`;`をすべて`:`に置き換えているだけです 